### PR TITLE
fix: prevent horizontal scrollbar on mobile

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -815,6 +815,7 @@ const tickerUnits = [
 .step-code pre {
   margin: 0;
   padding: 1rem;
+  overflow-x: auto;
 }
 
 .step-code code {
@@ -880,6 +881,7 @@ const tickerUnits = [
 
   .steps-code-panel {
     position: static;
+    overflow: hidden;
   }
 }
 

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -545,6 +545,7 @@
 /* Smooth scrolling */
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 /* Transition for dark mode toggle */


### PR DESCRIPTION
Fixes horizontal scrollbar on mobile caused by:

- **Homepage code snippets**: Long XML code in the "How it Works" steps overflows on narrow screens. Added `overflow-x: auto` on `pre` blocks and `overflow: hidden` on the code panel for mobile.
- **Body overflow**: Added `overflow-x: hidden` on `html` root to catch any other overflow sources.

Also pushed a matching fix to schema.unitsml.org (namespace URIs).