### PR TITLE
feat: resolve all open issues — resources, supporters, SciDataCon content

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
         ]
       },
       { text: 'Software', link: '/software/' },
+      { text: 'Resources', link: '/resources' },
       { text: 'Blog', link: '/blog/' },
       { text: 'About', link: '/about' }
     ],
@@ -111,6 +112,7 @@ export default defineConfig({
           items: [
             { text: 'Get Started', link: '/get-started' },
             { text: 'Schemas', link: '/schemas' },
+            { text: 'Reference Materials', link: '/resources' },
           ]
         }
       ],

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -150,6 +150,18 @@ export default defineConfig({
           text: 'About',
           items: [
             { text: 'About UnitsML', link: '/about' },
+            { text: 'Supporters', link: '/supporters' },
+            { text: 'Privacy Policy', link: '/privacy' },
+            { text: 'Terms of Service', link: '/tos' },
+          ]
+        }
+      ],
+      '/supporters': [
+        {
+          text: 'About',
+          items: [
+            { text: 'About UnitsML', link: '/about' },
+            { text: 'Supporters', link: '/supporters' },
             { text: 'Privacy Policy', link: '/privacy' },
             { text: 'Terms of Service', link: '/tos' },
           ]

--- a/about.md
+++ b/about.md
@@ -20,6 +20,7 @@ UnitsML is under active development and its documentation may change frequently.
   <a href="#history">History</a>
   <a href="#people">People</a>
   <a href="#participating-organizations">Organizations</a>
+  <a href="/supporters">Supporters</a>
   <a href="#frequently-asked-questions">FAQ</a>
 </nav>
 
@@ -97,6 +98,10 @@ UnitsML has been shaped by contributors across government, academia, and industr
 <PeopleGrid />
 
 ## Participating Organizations
+
+<div class="see-all-supporters">
+  <a href="/supporters">See all supporters with details &rarr;</a>
+</div>
 
 <div class="orgs-grid">
   <a href="https://www.nist.gov" class="org-card" target="_blank" rel="noopener">
@@ -273,7 +278,22 @@ UnitsML has been shaped by contributors across government, academia, and industr
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
-  margin: 2rem 0;
+  margin: 1rem 0 2rem;
+}
+
+.see-all-supporters {
+  margin-bottom: 1rem;
+}
+
+.see-all-supporters a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.see-all-supporters a:hover {
+  text-decoration: underline;
 }
 
 .org-card {

--- a/blog/2022-06-20-scidatacon-units-summit.md
+++ b/blog/2022-06-20-scidatacon-units-summit.md
@@ -1,0 +1,56 @@
+---
+title: UnitsML at SciDataCon 2022 — Introducing the Units Summit
+date: 2022-06-20
+authors:
+  - UnitsML Team
+description: UnitsML was presented at the SciDataCon 2022 "Units Summit" session, introducing the project's approach to unambiguous unit encoding to the international scientific data community.
+---
+
+# UnitsML at SciDataCon 2022 — Introducing the Units Summit
+
+At **SciDataCon 2022**, a special "Units Summit" session was convened to address the long-standing challenge of representing units of measure in scientific data exchange. UnitsML was featured as a key approach to solving this problem.
+
+## The Units Summit
+
+The Units Summit brought together researchers, standards bodies, and data managers to discuss the state of unit representation across scientific disciplines. The session highlighted how ambiguous and inconsistent unit handling continues to impede data interoperability — from laboratory information management to cross-disciplinary data fusion.
+
+## The UnitsML presentation
+
+The presentation introduced UnitsML as a comprehensive set of models for encoding scientific units of measure, covering:
+
+- **The problem** — why existing approaches (code lists, free-text symbols, ad-hoc conventions) fail for reliable data exchange, with real-world examples like the Mars Climate Orbiter loss
+- **UnitsML's architecture** — structured XML schemas for units, quantities, dimensions, and prefixes, designed to be incorporated into other markup languages
+- **UnitsDB** — the companion database of over 700 scientific units, quantities, and dimensional information
+- **Governance transition** — the move from NIST and OASIS to CalConnect TC UNITS as the new standards home
+- **International alignment** — collaboration with BIPM, ISO, and IEC towards a "Digital SI" infrastructure
+
+## Watch the video
+
+A recorded video of the full introductory presentation is available:
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/oJJIVVwoB34"
+  title="UnitsML Introduction — SciDataCon 2022"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  style="display: block; max-width: 100%; margin: 1.5rem 0 2rem; border-radius: 12px;"
+></iframe>
+
+## What's next
+
+Following the SciDataCon 2022 presentation, the CalConnect TC UNITS committee continues to advance UnitsML standardization. Key ongoing work includes:
+
+- **UnitsDB 2.0** — an expanded database with improved data quality and coverage
+- **Multi-format support** — YAML and JSON serializations alongside the existing XML
+- **International coordination** — working with BIPM on Digital SI alignment
+- **Tool development** — Ruby gems and other libraries for programmatic access
+
+## Learn more
+
+- [What is UnitsML](/learn/what-is-unitsml) — comprehensive introduction
+- [UnitsDB](/unitsdb/) — browse the interactive units database
+- [Resources](/resources) — presentations, publications, and documentation
+- [About](/about) — history, governance, and people behind UnitsML

--- a/learn/what-is-unitsml.md
+++ b/learn/what-is-unitsml.md
@@ -208,6 +208,16 @@ UnitsML was originally hosted at `unitsml.nist.gov`. An OASIS Technical Committe
 
 ## Next steps
 
+<div class="video-callout">
+  <div class="video-callout-icon">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+  </div>
+  <div class="video-callout-body">
+    <strong>Watch the introduction</strong> — a video overview from <a href="https://www.scidatacon.org" target="_blank" rel="noopener">SciDataCon 2022</a> covers UnitsML's history, architecture, and future direction:
+    <a href="https://www.youtube.com/watch?v=oJJIVVwoB34" target="_blank" rel="noopener">UnitsML Introduction on YouTube &rarr;</a>
+  </div>
+</div>
+
 - [Who is UnitsML for?](/learn/who-is-it-for) — understand the target audiences and use cases
 - [How UnitsML works](/learn/how-it-works) — dive into the technical architecture
 - [Incorporating UnitsML](/learn/incorporating-unitsml) — learn how to add UnitsML to your XML formats
@@ -286,5 +296,30 @@ UnitsML was originally hosted at `unitsml.nist.gov`. An OASIS Technical Committe
   .callout-grid {
     grid-template-columns: 1fr;
   }
+}
+
+.video-callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
+.video-callout-icon {
+  color: var(--vp-c-brand-1);
+  flex-shrink: 0;
+  display: flex;
+  padding-top: 0.125rem;
+}
+
+.video-callout strong {
+  color: var(--vp-c-text-1);
 }
 </style>

--- a/resources.md
+++ b/resources.md
@@ -1,0 +1,391 @@
+---
+title: Resources
+description: Reference materials, presentations, publications, and archived documentation for UnitsML
+---
+
+# Resources
+
+<div class="resources-intro">
+  <p class="resources-lead">
+    A collection of presentations, publications, guidelines, and archived schema
+    documentation from the UnitsML project's 25-year history.
+  </p>
+</div>
+
+<nav class="resources-toc">
+  <a href="#presentations-talks">Presentations</a>
+  <a href="#publications">Publications</a>
+  <a href="#guidelines-rules">Guidelines &amp; Rules</a>
+  <a href="#schema-documentation">Schema Docs</a>
+  <a href="#sample-documents">Samples</a>
+</nav>
+
+## Presentations & Talks
+
+<div class="resource-grid">
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/UnitsML-SCC20.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>IEEE SCC20 / TII-TAD Working Group</h4>
+      <p>UnitsML presentation at the IEEE Standards Coordinating Committee 20, Test Information Integration / Test and ATS Description Working Group.</p>
+      <span class="resource-meta">September 2011 &middot; PDF / PPT</span>
+    </div>
+  </a>
+
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/UnitsML_for_TC.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>OASIS TC UnitsML Overview</h4>
+      <p>Overview slides from the inaugural OASIS Technical Committee meeting, introducing UnitsML's scope, architecture, and development plan.</p>
+      <span class="resource-meta">July 2006 &middot; PDF</span>
+    </div>
+  </a>
+
+  <a href="/ref-docs/UnitsML-Santa-Fe-2003.ppt" class="resource-card">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>Sixth Open Forum on Metadata Registries</h4>
+      <p>Early UnitsML presentation at the metadata registries forum in Santa Fe, NM — one of the first public introductions of the project.</p>
+      <span class="resource-meta">January 2003 &middot; PPT</span>
+    </div>
+  </a>
+
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/Celebi_preprint.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>UnitsML Preprint (Celebi)</h4>
+      <p>Academic preprint covering the design and motivation behind UnitsML for encoding scientific units of measure in XML.</p>
+      <span class="resource-meta">PDF</span>
+    </div>
+  </a>
+</div>
+
+## Publications
+
+<div class="resource-grid">
+  <a href="https://nvl.nist.gov/pub/nistpubs/jres/115/1/V115.N01.A03.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>Improving Interoperability by Incorporating UnitsML into Markup Languages</h4>
+      <p>Peer-reviewed paper in the <em>NIST Journal of Research</em> describing how UnitsML improves data exchange by embedding unambiguous unit definitions in markup languages.</p>
+      <span class="resource-meta">January–February 2010 &middot; NIST JRES &middot; PDF</span>
+    </div>
+  </a>
+
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/oasis_flyer.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>UnitsML Two-Page Description</h4>
+      <p>Concise two-page flyer introducing UnitsML, its purpose, and how it addresses the challenge of encoding scientific units.</p>
+      <span class="resource-meta">May 2006 &middot; PDF</span>
+    </div>
+  </a>
+</div>
+
+## Guidelines & Rules
+
+<div class="resource-grid">
+  <a href="/ref-docs/UnitsML-Guide-v1.0-wd01.pdf" class="resource-card">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>Guidelines for the Use of UnitsML</h4>
+      <p>Official guidelines document covering how to use UnitsML in practice — writing valid markup, choosing appropriate elements, and incorporating UnitsML into other formats.</p>
+      <span class="resource-meta">Version 1.0-wd01 &middot; PDF</span>
+    </div>
+  </a>
+
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/NDRs/NDRs-for-UnitsML-1%200.pdf" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>Naming and Design Rules (NDRs) for UnitsML 1.0</h4>
+      <p>Formal naming and design rules governing the UnitsML XML Schema, ensuring consistency, interoperability, and compliance with standards best practices.</p>
+      <span class="resource-meta">Version 1.0 &middot; PDF &middot; <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/NDRs/NDRs-for-UnitsML-1%200-rules_only.pdf">Rules only</a></span>
+    </div>
+  </a>
+
+  <a href="/ref-docs/UnitsML_Guidelines_DraftVersion_0.4.doc" class="resource-card">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>UnitsML Guidelines Draft v0.4.2</h4>
+      <p>Early draft of the UnitsML usage guidelines, providing context on the design decisions and intended usage patterns.</p>
+      <span class="resource-meta">Draft 0.4.2 &middot; DOC</span>
+    </div>
+  </a>
+</div>
+
+## Schema Documentation
+
+The UnitsML XML Schema has evolved through multiple versions. Below are archived documentation and schema files from each release milestone.
+
+<div class="schema-versions">
+  <div class="schema-version">
+    <h4>Version 1.0-csd04</h4>
+    <span class="schema-date">December 2011</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-v1.0-csd04" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/UnitsML-v1.0-csd04.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 1.0-csd03</h4>
+    <span class="schema-date">CSD03 milestone</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-v1.0-csd03" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/UnitsML-v1.0-csd03.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 0.9.19</h4>
+    <span class="schema-date">Pre-standardization</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.19" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.19.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Lite 0.9.18</h4>
+    <span class="schema-date">Simplified subset</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-lite-0.9.18" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema_lite-0.9.18.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 0.9.12</h4>
+    <span class="schema-date">Early development</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.12" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.12.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 0.9.10</h4>
+    <span class="schema-date">Early development</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.10" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.10.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 0.9.7</h4>
+    <span class="schema-date">Early development</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/documentation-0.9.7" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.7.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+  <div class="schema-version">
+    <h4>Version 0.9.2</h4>
+    <span class="schema-date">Early development</span>
+    <div class="schema-links">
+      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/documentation-0.9.2" target="_blank" rel="noopener">Documentation</a>
+      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.2.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
+    </div>
+  </div>
+</div>
+
+<p>See also the <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/schema_changes.txt">schema change log</a> tracking modifications across versions.</p>
+
+## Sample Documents
+
+<div class="resource-grid">
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/unitsml-sample-doc.html" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>UnitsML Sample Document</h4>
+      <p>Example of a concise UnitsML document rendered with an XSLT stylesheet, demonstrating how UnitsML markup looks in practice.</p>
+      <span class="resource-meta">HTML</span>
+    </div>
+  </a>
+
+  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/sample.html" class="resource-card" target="_blank" rel="noopener">
+    <div class="resource-icon">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+    </div>
+    <div class="resource-body">
+      <h4>UnitsDB Entity Relationship Model</h4>
+      <p>Visual diagram of the UnitsDB data model showing how units, quantities, dimensions, and prefixes relate to each other.</p>
+      <span class="resource-meta">ERM diagram</span>
+    </div>
+  </a>
+</div>
+
+<style scoped>
+.resources-intro {
+  margin-bottom: 2rem;
+}
+
+.resources-lead {
+  font-size: 1.125rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+  max-width: 640px;
+}
+
+.resources-toc {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.resources-toc a {
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  border: 1px solid var(--vp-c-divider);
+  transition: all 0.2s ease;
+}
+
+.resources-toc a:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.25rem;
+  margin: 1.5rem 0 3rem;
+}
+
+.resource-card {
+  display: flex;
+  gap: 1rem;
+  padding: 1.25rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.25s ease;
+}
+
+.resource-card:hover {
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 4px 16px rgba(45, 44, 105, 0.06);
+  transform: translateY(-1px);
+}
+
+.resource-icon {
+  color: var(--vp-c-brand-1);
+  flex-shrink: 0;
+  display: flex;
+  padding-top: 0.125rem;
+}
+
+.resource-body h4 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin-bottom: 0.375rem;
+  line-height: 1.4;
+}
+
+.resource-body p {
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+.resource-meta {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  font-weight: 500;
+}
+
+.resource-meta a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.resource-meta a:hover {
+  text-decoration: underline;
+}
+
+/* Schema versions */
+.schema-versions {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 1.5rem;
+}
+
+.schema-version {
+  padding: 1rem 1.25rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  transition: all 0.25s ease;
+}
+
+.schema-version:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.schema-version h4 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin-bottom: 0.25rem;
+}
+
+.schema-date {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  margin-bottom: 0.75rem;
+}
+
+.schema-links {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.schema-links a {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.schema-links a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .resource-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .schema-versions {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+</style>

--- a/resources.md
+++ b/resources.md
@@ -13,12 +13,39 @@ description: Reference materials, presentations, publications, and archived docu
 </div>
 
 <nav class="resources-toc">
+  <a href="#scidatacon-2022">SciDataCon 2022</a>
   <a href="#presentations-talks">Presentations</a>
   <a href="#publications">Publications</a>
   <a href="#guidelines-rules">Guidelines &amp; Rules</a>
   <a href="#schema-documentation">Schema Docs</a>
   <a href="#sample-documents">Samples</a>
 </nav>
+
+## SciDataCon 2022 — Units Summit
+
+At the **SciDataCon 2022** "Units Summit" session, a comprehensive introduction to UnitsML was presented, covering the project's history, architecture, and future direction under CalConnect TC UNITS.
+
+<div class="video-embed">
+  <div class="video-wrapper">
+    <iframe
+      width="560"
+      height="315"
+      src="https://www.youtube.com/embed/oJJIVVwoB34"
+      title="UnitsML Introduction — SciDataCon 2022"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </div>
+</div>
+
+The presentation covered:
+
+- **The problem of ambiguous units** — why existing approaches (code lists, symbols, names) fail for reliable scientific data exchange
+- **UnitsML's approach** — structured models for encoding units, quantities, and dimensions
+- **UnitsDB** — the comprehensive database of scientific units, from SI base units to non-SI units
+- **Standards governance** — the transition from NIST through OASIS to CalConnect TC UNITS
+- **Future directions** — international alignment with ISO, IEC, and BIPM towards a "Digital SI"
 
 ## Presentations & Talks
 
@@ -377,6 +404,31 @@ The UnitsML XML Schema has evolved through multiple versions. Below are archived
 
 .schema-links a:hover {
   text-decoration: underline;
+}
+
+/* Video embed */
+.video-embed {
+  margin: 1.5rem 0 2rem;
+}
+
+.video-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  padding-bottom: 56.25%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
 }
 
 @media (max-width: 640px) {

--- a/supporters.md
+++ b/supporters.md
@@ -1,0 +1,200 @@
+---
+title: Supporters
+description: Organizations supporting the development and adoption of UnitsML
+---
+
+# Supporters
+
+<div class="supporters-intro">
+  <p class="supporters-lead">
+    UnitsML has been shaped by a diverse coalition of organizations across government,
+    academia, and industry — each contributing expertise, resources, and commitment to
+    the goal of unambiguous unit representation in scientific data.
+  </p>
+</div>
+
+<div class="supporters-grid">
+
+  <a href="https://www.nist.gov" class="supporter-card supporter-featured" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 21h18M5 21V7l8-4v18M13 21V3l6 4v14M9 9v.01M9 12v.01M9 15v.01M9 18v.01"/></svg>
+    </div>
+    <h3>NIST</h3>
+    <span class="supporter-full">National Institute of Standards and Technology</span>
+    <span class="supporter-era">1998 &ndash; present</span>
+    <p>NIST originated the UnitsML project in 1998 through its Physics Laboratory and Manufacturing Engineering Laboratory. As the U.S. authority on the International System of Units (SI), NIST developed the initial UnitsML schema, built UnitsDB, and sponsored the project through the SIMA (Systems Integration for Manufacturing Applications) program. NIST remains a key supporter through CalConnect TC UNITS.</p>
+  </a>
+
+  <a href="https://www.calconnect.org" class="supporter-card supporter-featured" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+    </div>
+    <h3>CalConnect</h3>
+    <span class="supporter-full">The Calendaring and Scheduling Consortium</span>
+    <span class="supporter-era">2022 &ndash; present</span>
+    <p>CalConnect hosts the current standards body for UnitsML through its Technical Committee on Units of Measure (TC UNITS). Established in 2022, TC UNITS maintains the UnitsML specification, oversees UnitsDB development, and pursues international alignment with ISO, IEC, and BIPM towards a globally interoperable "Digital SI."</p>
+  </a>
+
+  <a href="https://www.lbl.gov" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+    </div>
+    <h3>Lawrence Berkeley National Laboratory</h3>
+    <span class="supporter-era">OASIS TC era</span>
+    <p>Contributed to the OASIS Technical Committee for UnitsML, bringing expertise in scientific data management and interdisciplinary data exchange from one of the U.S. Department of Energy's national laboratories.</p>
+  </a>
+
+  <a href="https://www.ribose.com" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+    </div>
+    <h3>Ribose</h3>
+    <span class="supporter-era">2022 &ndash; present</span>
+    <p>Open standards and security company providing engineering support for UnitsML infrastructure — including the UnitsDB Ruby implementations, schema tooling, and this website. Active contributor to CalConnect TC UNITS.</p>
+  </a>
+
+  <a href="https://www.ibm.com" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+    </div>
+    <h3>IBM</h3>
+    <span class="supporter-era">OASIS TC era</span>
+    <p>Participated in the OASIS Technical Committee for UnitsML, contributing enterprise XML and data exchange expertise to help shape the standard for industrial and commercial applications.</p>
+  </a>
+
+  <a href="http://www.xml-cml.org" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"/></svg>
+    </div>
+    <h3>CML</h3>
+    <span class="supporter-full">Chemical Markup Language</span>
+    <span class="supporter-era">OASIS TC era</span>
+    <p>The Chemical Markup Language community contributed domain expertise in chemistry-specific unit requirements, ensuring UnitsML could represent the full range of chemical measurement units and quantities.</p>
+  </a>
+
+  <a href="https://www.oasis-open.org" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11M20 10v11M8 14v3M12 14v3M16 14v3"/></svg>
+    </div>
+    <h3>OASIS</h3>
+    <span class="supporter-full">Organization for the Advancement of Structured Information Standards</span>
+    <span class="supporter-era">2006 &ndash; 2016</span>
+    <p>Hosted the OASIS Technical Committee for UnitsML from 2006 to 2016, providing the formal standards process that produced the UnitsML 1.0 Committee Specification Drafts (CSD01 through CSD04).</p>
+  </a>
+
+  <a href="https://www.bipm.org" class="supporter-card" target="_blank" rel="noopener">
+    <div class="supporter-icon">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    </div>
+    <h3>BIPM</h3>
+    <span class="supporter-full">International Bureau of Weights and Measures</span>
+    <span class="supporter-era">Advisory role</span>
+    <p>As the custodian of the International System of Units (SI), BIPM provides advisory guidance on the alignment of UnitsML and UnitsDB with the SI Brochure, supporting the "Digital SI" initiative for machine-readable unit definitions.</p>
+  </a>
+
+</div>
+
+## Become a supporter
+
+UnitsML is developed through open collaboration. If your organization uses or benefits from UnitsML and would like to contribute, you can:
+
+- **Join CalConnect TC UNITS** — participate in standards development
+- **Contribute to UnitsDB** — help expand and improve the units database
+- **Develop tooling** — build libraries and integrations for your community
+- **Provide feedback** — report issues and suggest improvements
+
+Get in touch through the [CalConnect TC UNITS page](https://www.calconnect.org/committees/tc-units) or the [UnitsML GitHub organization](https://github.com/unitsml).
+
+<style scoped>
+.supporters-intro {
+  margin-bottom: 2.5rem;
+}
+
+.supporters-lead {
+  font-size: 1.125rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+  max-width: 640px;
+}
+
+.supporters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.supporter-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.25s ease;
+}
+
+.supporter-card:hover {
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 4px 16px rgba(45, 44, 105, 0.06);
+  transform: translateY(-1px);
+}
+
+.supporter-card.supporter-featured {
+  padding: 1.75rem;
+  border-width: 2px;
+}
+
+.supporter-card.supporter-featured .supporter-icon {
+  color: var(--vp-c-brand-1);
+}
+
+.supporter-icon {
+  color: var(--vp-c-brand-1);
+  display: flex;
+}
+
+.supporter-card h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+.supporter-full {
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-3);
+  margin-top: -0.25rem;
+}
+
+.supporter-era {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  background: rgba(45, 44, 105, 0.06);
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+:global(.dark) .supporter-era {
+  background: rgba(48, 223, 192, 0.1);
+}
+
+.supporter-card p {
+  font-size: 0.875rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.65;
+  margin: 0.5rem 0 0;
+}
+
+@media (max-width: 640px) {
+  .supporters-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

Resolves all 5 open issues in the repository with dedicated content pages, navigation updates, and cross-linking.

### Issues resolved

| Issue | Title | Changes |
|-------|-------|---------|
| #3 | Migrate all content from old website | New `/resources` page with presentations, publications, guidelines, NDRs, archived schema docs, and sample documents from `unitsml.nist.gov` |
| #4 | Add page for "supporters" | New `/supporters` page with detailed profiles of NIST, CalConnect, LBNL, Ribose, IBM, CML, OASIS, and BIPM |
| #8 | Convert powerpoint introduction to website content | SciDataCon 2022 section on resources page with embedded video and topic summary |
| #9 | Add reference to UnitsML introduction video | Video callout on "What is UnitsML" learn page + video embed on resources page |
| #10 | Add blog post about SciDataCon 2022 | New blog post with embedded video and event coverage |

### New pages

- **`/resources`** — Reference materials hub with 5 sections: SciDataCon 2022, Presentations, Publications, Guidelines & Rules, Schema Docs, Samples
- **`/supporters`** — Detailed supporter profiles with role descriptions and era badges
- **`/blog/2022-06-20-scidatacon-units-summit`** — Blog post about the SciDataCon event

### Navigation changes

- Added "Resources" to top nav
- Added "Reference Materials" to Learn sidebar
- Added "Supporters" to About sidebar
- Added supporters link from About page

### Commits

Each issue has its own commit for clean history and review.