### PR TITLE
fix: remove dead links and redundant sections from resources page

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -7,8 +7,8 @@ description: Reference materials, presentations, publications, and archived docu
 
 <div class="resources-intro">
   <p class="resources-lead">
-    A collection of presentations, publications, guidelines, and archived schema
-    documentation from the UnitsML project's 25-year history.
+    A collection of presentations, publications, and guidelines
+    from the UnitsML project's 25-year history.
   </p>
 </div>
 
@@ -17,8 +17,6 @@ description: Reference materials, presentations, publications, and archived docu
   <a href="#presentations-talks">Presentations</a>
   <a href="#publications">Publications</a>
   <a href="#guidelines-rules">Guidelines &amp; Rules</a>
-  <a href="#schema-documentation">Schema Docs</a>
-  <a href="#sample-documents">Samples</a>
 </nav>
 
 ## SciDataCon 2022 — Units Summit
@@ -50,28 +48,6 @@ The presentation covered:
 ## Presentations & Talks
 
 <div class="resource-grid">
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/UnitsML-SCC20.pdf" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>IEEE SCC20 / TII-TAD Working Group</h4>
-      <p>UnitsML presentation at the IEEE Standards Coordinating Committee 20, Test Information Integration / Test and ATS Description Working Group.</p>
-      <span class="resource-meta">September 2011 &middot; PDF / PPT</span>
-    </div>
-  </a>
-
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/UnitsML_for_TC.pdf" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>OASIS TC UnitsML Overview</h4>
-      <p>Overview slides from the inaugural OASIS Technical Committee meeting, introducing UnitsML's scope, architecture, and development plan.</p>
-      <span class="resource-meta">July 2006 &middot; PDF</span>
-    </div>
-  </a>
-
   <a href="/ref-docs/UnitsML-Santa-Fe-2003.ppt" class="resource-card">
     <div class="resource-icon">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
@@ -82,23 +58,12 @@ The presentation covered:
       <span class="resource-meta">January 2003 &middot; PPT</span>
     </div>
   </a>
-
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/Celebi_preprint.pdf" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>UnitsML Preprint (Celebi)</h4>
-      <p>Academic preprint covering the design and motivation behind UnitsML for encoding scientific units of measure in XML.</p>
-      <span class="resource-meta">PDF</span>
-    </div>
-  </a>
 </div>
 
 ## Publications
 
 <div class="resource-grid">
-  <a href="https://nvl.nist.gov/pub/nistpubs/jres/115/1/V115.N01.A03.pdf" class="resource-card" target="_blank" rel="noopener">
+  <a href="/ref-docs/Improving_Interoperability_by_Incorporating_UnitsM.pdf" class="resource-card">
     <div class="resource-icon">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
     </div>
@@ -106,17 +71,6 @@ The presentation covered:
       <h4>Improving Interoperability by Incorporating UnitsML into Markup Languages</h4>
       <p>Peer-reviewed paper in the <em>NIST Journal of Research</em> describing how UnitsML improves data exchange by embedding unambiguous unit definitions in markup languages.</p>
       <span class="resource-meta">January–February 2010 &middot; NIST JRES &middot; PDF</span>
-    </div>
-  </a>
-
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Presentations/oasis_flyer.pdf" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>UnitsML Two-Page Description</h4>
-      <p>Concise two-page flyer introducing UnitsML, its purpose, and how it addresses the challenge of encoding scientific units.</p>
-      <span class="resource-meta">May 2006 &middot; PDF</span>
     </div>
   </a>
 </div>
@@ -135,17 +89,6 @@ The presentation covered:
     </div>
   </a>
 
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/NDRs/NDRs-for-UnitsML-1%200.pdf" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>Naming and Design Rules (NDRs) for UnitsML 1.0</h4>
-      <p>Formal naming and design rules governing the UnitsML XML Schema, ensuring consistency, interoperability, and compliance with standards best practices.</p>
-      <span class="resource-meta">Version 1.0 &middot; PDF &middot; <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/NDRs/NDRs-for-UnitsML-1%200-rules_only.pdf">Rules only</a></span>
-    </div>
-  </a>
-
   <a href="/ref-docs/UnitsML_Guidelines_DraftVersion_0.4.doc" class="resource-card">
     <div class="resource-icon">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
@@ -154,105 +97,6 @@ The presentation covered:
       <h4>UnitsML Guidelines Draft v0.4.2</h4>
       <p>Early draft of the UnitsML usage guidelines, providing context on the design decisions and intended usage patterns.</p>
       <span class="resource-meta">Draft 0.4.2 &middot; DOC</span>
-    </div>
-  </a>
-</div>
-
-## Schema Documentation
-
-The UnitsML XML Schema has evolved through multiple versions. Below are archived documentation and schema files from each release milestone.
-
-<div class="schema-versions">
-  <div class="schema-version">
-    <h4>Version 1.0-csd04</h4>
-    <span class="schema-date">December 2011</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-v1.0-csd04" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/UnitsML-v1.0-csd04.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 1.0-csd03</h4>
-    <span class="schema-date">CSD03 milestone</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-v1.0-csd03" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/UnitsML-v1.0-csd03.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 0.9.19</h4>
-    <span class="schema-date">Pre-standardization</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.19" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.19.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Lite 0.9.18</h4>
-    <span class="schema-date">Simplified subset</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-lite-0.9.18" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema_lite-0.9.18.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 0.9.12</h4>
-    <span class="schema-date">Early development</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.12" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.12.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 0.9.10</h4>
-    <span class="schema-date">Early development</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/Documentation-0.9.10" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.10.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 0.9.7</h4>
-    <span class="schema-date">Early development</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/documentation-0.9.7" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.7.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-  <div class="schema-version">
-    <h4>Version 0.9.2</h4>
-    <span class="schema-date">Early development</span>
-    <div class="schema-links">
-      <a href="https://github.com/unitsml/unitsml.nist.gov/tree/main/Schema/documentation-0.9.2" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/unitsmlSchema-0.9.2.xsd" target="_blank" rel="noopener">Schema (XSD)</a>
-    </div>
-  </div>
-</div>
-
-<p>See also the <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/Schema/schema_changes.txt">schema change log</a> tracking modifications across versions.</p>
-
-## Sample Documents
-
-<div class="resource-grid">
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/unitsml-sample-doc.html" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>UnitsML Sample Document</h4>
-      <p>Example of a concise UnitsML document rendered with an XSLT stylesheet, demonstrating how UnitsML markup looks in practice.</p>
-      <span class="resource-meta">HTML</span>
-    </div>
-  </a>
-
-  <a href="https://github.com/unitsml/unitsml.nist.gov/blob/main/sample.html" class="resource-card" target="_blank" rel="noopener">
-    <div class="resource-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-    </div>
-    <div class="resource-body">
-      <h4>UnitsDB Entity Relationship Model</h4>
-      <p>Visual diagram of the UnitsDB data model showing how units, quantities, dimensions, and prefixes relate to each other.</p>
-      <span class="resource-meta">ERM diagram</span>
     </div>
   </a>
 </div>
@@ -347,65 +191,6 @@ The UnitsML XML Schema has evolved through multiple versions. Below are archived
   font-weight: 500;
 }
 
-.resource-meta a {
-  color: var(--vp-c-brand-1);
-  text-decoration: none;
-}
-
-.resource-meta a:hover {
-  text-decoration: underline;
-}
-
-/* Schema versions */
-.schema-versions {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 1.5rem;
-}
-
-.schema-version {
-  padding: 1rem 1.25rem;
-  background: var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
-  transition: all 0.25s ease;
-}
-
-.schema-version:hover {
-  border-color: var(--vp-c-brand-1);
-}
-
-.schema-version h4 {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1);
-  margin-bottom: 0.25rem;
-}
-
-.schema-date {
-  display: block;
-  font-size: 0.75rem;
-  color: var(--vp-c-text-3);
-  margin-bottom: 0.75rem;
-}
-
-.schema-links {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.schema-links a {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--vp-c-brand-1);
-  text-decoration: none;
-}
-
-.schema-links a:hover {
-  text-decoration: underline;
-}
-
 /* Video embed */
 .video-embed {
   margin: 1.5rem 0 2rem;
@@ -434,10 +219,6 @@ The UnitsML XML Schema has evolved through multiple versions. Below are archived
 @media (max-width: 640px) {
   .resource-grid {
     grid-template-columns: 1fr;
-  }
-
-  .schema-versions {
-    grid-template-columns: 1fr 1fr;
   }
 }
 </style>

--- a/supporters.md
+++ b/supporters.md
@@ -103,7 +103,7 @@ UnitsML is developed through open collaboration. If your organization uses or be
 - **Develop tooling** — build libraries and integrations for your community
 - **Provide feedback** — report issues and suggest improvements
 
-Get in touch through the [CalConnect TC UNITS page](https://www.calconnect.org/committees/tc-units) or the [UnitsML GitHub organization](https://github.com/unitsml).
+Get in touch through the [CalConnect TC UNITS page](https://www.calconnect.org/about/technical-committees/tc-units/) or the [UnitsML GitHub organization](https://github.com/unitsml).
 
 <style scoped>
 .supporters-intro {


### PR DESCRIPTION
## Problem

The resources page at /resources.html had multiple issues:

1. **25+ dead links** — All links to the old GitHub repo (`unitsml/unitsml.nist.gov`) return 404 because the repo has been deleted
2. **Redundant Schema Documentation section** — schema.unitsml.org already hosts all schema docs
3. **Wrong CalConnect TC UNITS URL** — `/committees/tc-units` was a 404

These issues would cause the lychee link checker CI to fail.

## Changes

- **Remove all resource cards** linking to the deleted `unitsml.nist.gov` repo (presentations, NDRs, schemas, samples)
- **Remove Schema Documentation section** entirely (redundant with schema.unitsml.org)
- **Remove Sample Documents section** (all links dead)
- **Keep only working cards** with local file links from `/ref-docs/`
- **Point NIST JRES publication** to local copy instead of the unreachable nvl.nist.gov URL
- **Fix CalConnect TC UNITS URL** in supporters.md (`/committees/tc-units` → `/about/technical-committees/tc-units/`)

## Remaining resources (all verified)

| Resource | Link | Status |
|----------|------|--------|
| SciDataCon 2022 video | YouTube embed | ✅ |
| Santa Fe 2003 presentation | `/ref-docs/UnitsML-Santa-Fe-2003.ppt` | ✅ |
| NIST JRES paper | `/ref-docs/Improving_Interoperability...` | ✅ |
| Guidelines v1.0-wd01 | `/ref-docs/UnitsML-Guide-v1.0-wd01.pdf` | ✅ |
| Guidelines Draft v0.4 | `/ref-docs/UnitsML_Guidelines_DraftVersion_0.4.doc` | ✅ |